### PR TITLE
Off-by-one Error When Highlighting Location, Require Config File, Better Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For example in Lazy.nvim add following to your plugins and correct the path
         checkstyle_file = "<your path to the checkstyle file>",
         checkstyle_on_write = true,
         -- uses always this severity level (nil or omitting uses the checkstyle's severity)
-        force_diagnostic = "WARN",  -- can be IGNORE, INFO, WARN, ERROR
+        force_severity = "WARN",  -- can be IGNORE, INFO, WARN, ERROR
         pattern = {"*.java"},  -- the pattern for the autocommand (defaults to {*.java})
     },
 },

--- a/lua/checkstyle-integration.lua
+++ b/lua/checkstyle-integration.lua
@@ -52,11 +52,8 @@ function M.java_checkstyle()
         hide = vim.fn.has("win32") == 1,
         stdio = { stdin, stdout, stderr }
     }, function(code, signal)
-        if code < 0 or code > 2 then
-            vim.schedule(function()
-                vim.notify("Checkstyle exited with code " .. code .. " and signal " .. signal, vim.diagnostic.severity.WARN)
-            end)
-        end
+        -- Checkstyle puts the number of violations into the exit code,
+        -- so sending a notification about it does not provide new information.
     end)
     if not handle then
         print("Handle unexpected close")

--- a/lua/checkstyle-integration.lua
+++ b/lua/checkstyle-integration.lua
@@ -10,7 +10,7 @@ local DIAGNOSTIC_MAP = {
 
 function M.setup(opts)
     if opts.checkstyle_file == nil then
-        vim.notify("No checkstyle file set", vim.diagnostic.severity.ERROR)
+        vim.notify("No checkstyle file set", vim.log.levels.ERROR)
         return
     end
 
@@ -37,7 +37,7 @@ end
 
 function M.java_checkstyle()
     if M.checkstyle_file == nil then
-        vim.notify("No checkstyle file set", vim.diagnostic.severity.ERROR)
+        vim.notify("No checkstyle file set", vim.log.levels.ERROR)
         return
     end
 
@@ -70,7 +70,7 @@ function M.java_checkstyle()
 
     uv.read_start(stdout, function(err, data)
         if err then
-            vim.notify("No checkstyle file set", vim.diagnostic.severity.ERROR)
+            vim.notify("No checkstyle file set", vim.log.levels.ERROR)
             -- TODO
         elseif data then
             output = output .. data
@@ -93,9 +93,9 @@ function M.java_checkstyle()
                 local old_cmd_height = vim.o.cmdheight;
                 vim.o.cmdheight = old_cmd_height + 1;
                 if line_count == 0 then
-                    vim.notify("No checkstyle violations", vim.diagnostic.severity.INFO)
+                    vim.notify("No checkstyle violations", vim.log.levels.INFO)
                 else
-                    vim.notify("Found " .. line_count .. " checkstyle violation(s)", vim.diagnostic.severity.WARN)
+                    vim.notify("Found " .. line_count .. " checkstyle violation(s)", vim.log.levels.WARN)
                 end
                 if old_cmd_height == nil then
                     vim.o.cmdheight = 1;

--- a/lua/checkstyle-integration.lua
+++ b/lua/checkstyle-integration.lua
@@ -54,7 +54,7 @@ function M.java_checkstyle()
     }, function(code, signal)
         if code < 0 or code > 2 then
             vim.schedule(function()
-                vim.notify("Code " .. code .. "; Signal " .. signal, vim.diagnostic.severity.WARN)
+                vim.notify("Checkstyle exited with code " .. code .. " and signal " .. signal, vim.diagnostic.severity.WARN)
             end)
         end
     end)
@@ -91,11 +91,11 @@ function M.java_checkstyle()
                 local old_cmd_height = vim.o.cmdheight;
                 vim.o.cmdheight = old_cmd_height + 1;
                 if line_count == 0 then
-                    print("You are good to go; No violations from checkstyle found", "")
+                    print("No checkstyle violations")
                 elseif line_count == 1 then
-                    print("Found", line_count, "check style violation")
+                    print("Found", line_count, "checkstyle violation")
                 else
-                    print("Found", line_count, "check style violations")
+                    print("Found", line_count, "checkstyle violations")
                 end
                 if old_cmd_height == nil then
                     vim.o.cmdheight = 1;
@@ -147,3 +147,4 @@ function M._convert_checkstyle_output_to_diagnostic(namespace, output)
 end
 
 return M;
+

--- a/lua/checkstyle-integration.lua
+++ b/lua/checkstyle-integration.lua
@@ -52,7 +52,7 @@ function M.java_checkstyle()
         hide = vim.fn.has("win32") == 1,
         stdio = { stdin, stdout, stderr }
     }, function(code, signal)
-        if code ~= 0 and code ~= 1 then
+        if code < 0 or code > 2 then
             vim.schedule(function()
                 vim.notify("Code " .. code .. "; Signal " .. signal, vim.diagnostic.severity.WARN)
             end)

--- a/lua/checkstyle-integration.lua
+++ b/lua/checkstyle-integration.lua
@@ -36,6 +36,11 @@ function M.setup(opts)
 end
 
 function M.java_checkstyle()
+    if M.checkstyle_file == nil then
+        vim.notify("No checkstyle file set", vim.diagnostic.severity.ERROR)
+        return
+    end
+
     local namespace = vim.api.nvim_create_namespace("checkstyle")
     local handle;
     local pid_or_err;

--- a/lua/checkstyle-integration.lua
+++ b/lua/checkstyle-integration.lua
@@ -10,7 +10,7 @@ local DIAGNOSTIC_MAP = {
 
 function M.setup(opts)
     if opts.checkstyle_file == nil then
-        print("No checkstyle file set")
+        vim.notify("No checkstyle file set", vim.diagnostic.severity.ERROR)
         return
     end
 
@@ -56,7 +56,7 @@ function M.java_checkstyle()
         -- so sending a notification about it does not provide new information.
     end)
     if not handle then
-        print("Handle unexpected close")
+        -- Handle unexpected close.
         stdin:close()
         stdout:close()
         stderr:close()
@@ -65,7 +65,7 @@ function M.java_checkstyle()
 
     uv.read_start(stdout, function(err, data)
         if err then
-            print(err)
+            vim.notify("No checkstyle file set", vim.diagnostic.severity.ERROR)
             -- TODO
         elseif data then
             output = output .. data
@@ -88,11 +88,9 @@ function M.java_checkstyle()
                 local old_cmd_height = vim.o.cmdheight;
                 vim.o.cmdheight = old_cmd_height + 1;
                 if line_count == 0 then
-                    print("No checkstyle violations")
-                elseif line_count == 1 then
-                    print("Found", line_count, "checkstyle violation")
+                    vim.notify("No checkstyle violations", vim.diagnostic.severity.INFO)
                 else
-                    print("Found", line_count, "checkstyle violations")
+                    vim.notify("Found " .. line_count .. " checkstyle violation(s)", vim.diagnostic.severity.WARN)
                 end
                 if old_cmd_height == nil then
                     vim.o.cmdheight = 1;

--- a/lua/checkstyle-integration.lua
+++ b/lua/checkstyle-integration.lua
@@ -134,8 +134,8 @@ function M._convert_checkstyle_output_to_diagnostic(namespace, output)
             namespace = namespace
         };
         if (line_col ~= nil) then
-            d.col = tonumber(line_col)
-            d.end_col = tonumber(line_col) + 1
+            d.col = tonumber(line_col) - 1
+            d.end_col = tonumber(line_col)
         else
             d.col = 0
         end


### PR DESCRIPTION
Hi, I have some small changes I made for making this plugin more pleasant to use. I'm including multiple different things in this pull request as they are quite small changes. If you would only like to merge parts of this, tell me and we can resolve it.

1. There was an off-by-one error when highlighting the location of the violations.
2. Notifications were sent if checkstyle returned with errors. This is quite annoying as checkstyle now puts the number of violations in its error code.
3. A more robust handing of a missing checkstyle configuration file.
4. The `force_diagnostic` option in the README.md is actually called `force_severity`.
5. The wrong kind of log level constants were used.

PS: Thanks for the plugin, it helps a lot for writhing Java for my courses.